### PR TITLE
Fixed structure of `timeupdate` event and typo on `volumechange` event

### DIFF
--- a/src/api/player.js
+++ b/src/api/player.js
@@ -186,11 +186,14 @@ Player.prototype.onMessage_ = function(event) {
       break;
     case 'volumechange':
       this.volume = data;
-      this.emit('timeupdate', data);
+      this.emit('volumechange', data);
       break;
     case 'timeupdate':
       this.currentTime = data;
-      this.emit('timeupdate', data);
+      this.emit('timeupdate', {
+        currentTime: this.currentTime,
+	duration: this.duration
+      });
       break;
     case 'play':
     case 'paused':

--- a/src/api/player.js
+++ b/src/api/player.js
@@ -192,7 +192,7 @@ Player.prototype.onMessage_ = function(event) {
       this.currentTime = data;
       this.emit('timeupdate', {
         currentTime: this.currentTime,
-	duration: this.duration
+        duration: this.duration
       });
       break;
     case 'play':


### PR DESCRIPTION
Currently, timeupdate event is broken, and following the HTML5 conventions of the event (https://msdn.microsoft.com/en-us/library/ff974185(v=vs.85).aspx), it should return currentTime and duration. And volumechange was emitting the wrong event. This PR fixed those issues. This is the fixed version of PR #171 