### PR TITLE
Adds support to "mute" attribute to be set by default.

### DIFF
--- a/examples/style.css
+++ b/examples/style.css
@@ -41,7 +41,7 @@ iframe {
     cursor: pointer;
     opacity: 0.5;
   }
- 
+
   #controls > *:hover {
     opacity: 1;
   }
@@ -74,6 +74,12 @@ iframe {
   #togglemute.muted {
     background: url('img/ic_volume_off_black_24dp.svg');
   }
+
+#volumerange {
+  float: right;
+  width: 100px;
+  height: 24px;
+}
 
 /* MOBILE */
 @media screen and (max-width: 700px) {

--- a/examples/video/index.html
+++ b/examples/video/index.html
@@ -19,6 +19,7 @@
     <div id="controls">
       <div id="toggleplay" class="paused"></div>
       <div id="time">00:00 | 00:00</div>
+      <input id="volumerange" type="range" min="0" max="100" value="100"/>
       <div id="togglemute"></div>
     </div>
 

--- a/examples/video/index.js
+++ b/examples/video/index.js
@@ -23,7 +23,8 @@ function onLoad() {
     height: 480,
     video: 'congo_2048.mp4',
     is_stereo: true,
-    loop: false,
+    loop: true,
+    //muted: false,
     //is_debug: true,
     //default_heading: 90,
     //is_yaw_only: true,
@@ -32,10 +33,13 @@ function onLoad() {
 
   playButton = document.querySelector('#toggleplay');
   muteButton = document.querySelector('#togglemute');
+  volumeRange = document.querySelector('#volumerange');
   timeContainer = document.querySelector('#time');
 
   playButton.addEventListener('click', onTogglePlay);
   muteButton.addEventListener('click', onToggleMute);
+  volumeRange.addEventListener('change', onVolumeChange);
+  volumeRange.addEventListener('input', onVolumeChange);
 
   vrView.on('ready', onVRViewReady);
 
@@ -81,11 +85,15 @@ function onTogglePlay() {
 function onToggleMute() {
   var isMuted = muteButton.classList.contains('muted');
   if (isMuted) {
-    vrView.setVolume(1);
+    vrView.mute(false);
   } else {
-    vrView.setVolume(0);
+    vrView.mute(true);
   }
   muteButton.classList.toggle('muted');
+}
+
+function onVolumeChange(e) {
+  vrView.setVolume(volumeRange.value / 100);
 }
 
 function formatTime(time) {

--- a/src/api/player.js
+++ b/src/api/player.js
@@ -47,6 +47,12 @@ function Player(selector, contentInfo) {
   // Expose a public .isPaused attribute.
   this.isPaused = false;
 
+  // Expose a plublic .isMuted attribute.
+  this.isMuted = false;
+  if (typeof contentInfo.muted !== 'undefined') {
+    this.isMuted = contentInfo.muted;
+  }
+
   // Other public attributes
   this.currentTime = 0;
   this.duration = 0;
@@ -115,6 +121,16 @@ Player.prototype.getVolume = function() {
 };
 
 /**
+ * Sets the mute state of the video element. true is muted, false is unmuted.
+ */
+Player.prototype.mute = function(muteState) {
+  var data = {
+    muteState: muteState
+  };
+  this.sender.send({type: Message.MUTED, data: data});
+};
+
+/**
  * Set the current time of the media being played
  * @param {Number} time
  */
@@ -170,7 +186,6 @@ Player.prototype.onMessage_ = function(event) {
   }
   var type = message.type.toLowerCase();
   var data = message.data;
-
   switch (type) {
     case 'ready':
     case 'modechange':
@@ -180,13 +195,17 @@ Player.prototype.onMessage_ = function(event) {
       if (type === 'ready') {
         if (data !== undefined) {
           this.duration = data.duration;
-	}
+        }
       }
       this.emit(type, data);
       break;
     case 'volumechange':
       this.volume = data;
       this.emit('volumechange', data);
+      break;
+    case 'muted':
+      this.isMuted = data;
+      this.emit('mute', data);
       break;
     case 'timeupdate':
       this.currentTime = data;

--- a/src/embed/adaptive-player.js
+++ b/src/embed/adaptive-player.js
@@ -36,6 +36,12 @@ function AdaptivePlayer(params) {
   if (params.loop === true) {
     this.video.setAttribute('loop', true);
   }
+
+  // Not muted by default.
+  if (params.muted === true) {
+    this.video.setAttribute('muted', true);
+  }
+
   // For FF, make sure we enable preload.
   this.video.setAttribute('preload', 'auto');
   // Enable inline video playback in iOS 10+.

--- a/src/embed/iframe-message-receiver.js
+++ b/src/embed/iframe-message-receiver.js
@@ -53,6 +53,7 @@ IFrameMessageReceiver.prototype.onMessage_ = function(event) {
     case Message.PLAY:
     case Message.PAUSE:
     case Message.SET_CURRENT_TIME:
+    case Message.MUTED:
       this.emit(type, data);
       break;
     default:

--- a/src/embed/main.js
+++ b/src/embed/main.js
@@ -37,6 +37,7 @@ receiver.on(Message.ADD_HOTSPOT, onAddHotspot);
 receiver.on(Message.SET_CONTENT, onSetContent);
 receiver.on(Message.SET_VOLUME, onSetVolume);
 receiver.on(Message.SET_CURRENT_TIME, onUpdateCurrentTime);
+receiver.on(Message.MUTED, onMuted);
 
 window.addEventListener('load', onLoad);
 
@@ -140,8 +141,6 @@ function onPlayRequest() {
     return;
   }
   worldRenderer.videoProxy.play();
-
-
 }
 
 function onPauseRequest() {
@@ -207,6 +206,21 @@ function onSetVolume(e) {
   });
 }
 
+function onMuted(e) {
+  // Only work for video. If there's no video, send back an error.
+  if (!worldRenderer.videoProxy) {
+    onApiError('Attempt to mute, but no video found.');
+    return;
+  }
+
+  worldRenderer.videoProxy.mute(e.muteState);
+
+  Util.sendParentMessage({
+    type: 'muted',
+    data: e.muteState
+  });
+}
+
 function onUpdateCurrentTime(time) {
   if (!worldRenderer.videoProxy) {
     onApiError('Attempt to pause, but no video found.');
@@ -260,6 +274,7 @@ function onPause() {
     data: true
   });
 }
+
 function onEnded() {
     Util.sendParentMessage({
       type: 'ended',

--- a/src/embed/scene-info.js
+++ b/src/embed/scene-info.js
@@ -18,6 +18,7 @@ var CAMEL_TO_UNDERSCORE = {
   image: 'image',
   preview: 'preview',
   loop: 'loop',
+  muted: 'muted',
   isStereo: 'is_stereo',
   defaultYaw: 'default_yaw',
   isYawOnly: 'is_yaw_only',
@@ -32,7 +33,8 @@ var CAMEL_TO_UNDERSCORE = {
 function SceneInfo(opt_params) {
   var params = opt_params || {};
   params.player = {
-    loop: opt_params.loop
+    loop: opt_params.loop,
+    muted: opt_params.muted
   };
 
   this.image = params.image;
@@ -46,6 +48,7 @@ function SceneInfo(opt_params) {
   this.isVROff = Util.parseBoolean(params.isVROff);
   this.isAutopanOff = Util.parseBoolean(params.isAutopanOff);
   this.loop = Util.parseBoolean(params.player.loop);
+  this.muted = Util.parseBoolean(params.player.muted);
 }
 
 SceneInfo.loadFromGetParams = function() {

--- a/src/embed/video-proxy.js
+++ b/src/embed/video-proxy.js
@@ -73,6 +73,20 @@ VideoProxy.prototype.setVolume = function(volumeLevel) {
   }
 };
 
+/**
+ * Set the attribute mute of the elements according with the muteState param.
+ *
+ * @param bool muteState
+ */
+VideoProxy.prototype.mute = function(muteState) {
+  if (this.videoElement) {
+    this.videoElement.muted = muteState;
+  }
+  if (this.audioElement) {
+    this.audioElement.muted = muteState;
+  }
+};
+
 VideoProxy.prototype.getCurrentTime = function() {
   return Util.isIOS9OrLess() ? this.audioElement.currentTime : this.videoElement.currentTime;
 };

--- a/src/embed/world-renderer.js
+++ b/src/embed/world-renderer.js
@@ -83,8 +83,10 @@ WorldRenderer.prototype.setScene = function(scene) {
 
   var params = {
     isStereo: scene.isStereo,
-    loop: scene.loop
+    loop: scene.loop,
+    muted: scene.muted
   };
+
   this.setDefaultYaw_(scene.defaultYaw || 0);
 
   // Disable VR mode if explicitly disabled, or if we're loading a video on iOS

--- a/src/message.js
+++ b/src/message.js
@@ -25,6 +25,7 @@ var Message = {
   SET_VOLUME: 'setvolume',
   SET_CURRENT_TIME: 'setcurrenttime',
   DEVICE_MOTION: 'devicemotion',
+  MUTED: 'muted',
 };
 
 module.exports = Message;


### PR DESCRIPTION
Today there is no way to mute videos by default.
To do that a workaround is needed to set the volume to "0" on the "ready" event. It causes some unwanted noises if the browser performance is not good.

If this pull request is accepted, developers can set the video to be muted by default.
Besides, I changed the volume icon to mute/unmute the video and added a volume range on the user interface to control the volume level.

This feature will be very useful to me in particular and hope this can help others too.