### PR TITLE
reorder render loop so focus is not called when loading new scene

### DIFF
--- a/src/embed/world-renderer.js
+++ b/src/embed/world-renderer.js
@@ -61,9 +61,9 @@ WorldRenderer.prototype = new EventEmitter();
 
 WorldRenderer.prototype.render = function(time) {
   this.controls.update();
-  this.hotspotRenderer.update(this.camera);
   TWEEN.update(time);
   this.effect.render(this.scene, this.camera);
+  this.hotspotRenderer.update(this.camera);
 };
 
 /**


### PR DESCRIPTION
When a scene is loaded that has hotspots, the focus_ method gets fired for each hotspot. This creates problems later on.

When raycaster.intersectObjects (within the render loop) is called for the first time when new content is loaded it returns every new Object3D in the scene, and focus_ gets called for each hotspot.

Moving the hotspotRenderer.update call below the effect render call stops this undesired behaviour. 

Fixes issue https://github.com/googlevr/vrview/issues/206