### PR TITLE
reset pose and account for camera rotation when loading scene

### DIFF
--- a/src/embed/world-renderer.js
+++ b/src/embed/world-renderer.js
@@ -236,8 +236,9 @@ WorldRenderer.prototype.setDefaultYaw_ = function(angleRad) {
   // Rotate the camera parent to take into account the scene's rotation.
   // By default, it should be at the center of the image.
   var display = this.controls.getVRDisplay();
+  // For desktop, we subtract the current display Y axis
   var theta = display.theta_ || 0;
-
+  // For devices with orientation we make the current view center
   if (display.poseSensor_) {
     display.poseSensor_.resetPose();
   }

--- a/src/embed/world-renderer.js
+++ b/src/embed/world-renderer.js
@@ -235,7 +235,13 @@ WorldRenderer.prototype.didLoadFail_ = function(message) {
 WorldRenderer.prototype.setDefaultYaw_ = function(angleRad) {
   // Rotate the camera parent to take into account the scene's rotation.
   // By default, it should be at the center of the image.
-  this.camera.parent.rotation.y = (Math.PI / 2.0) + angleRad;
+  var display = this.controls.getVRDisplay();
+  var theta = display.theta_ || 0;
+
+  if ( display.poseSensor_ ) {
+    display.poseSensor_.resetPose();
+  }
+  this.camera.parent.rotation.y = (Math.PI / 2.0) + angleRad - theta;
 };
 
 /**

--- a/src/embed/world-renderer.js
+++ b/src/embed/world-renderer.js
@@ -238,7 +238,7 @@ WorldRenderer.prototype.setDefaultYaw_ = function(angleRad) {
   var display = this.controls.getVRDisplay();
   var theta = display.theta_ || 0;
 
-  if ( display.poseSensor_ ) {
+  if (display.poseSensor_) {
     display.poseSensor_.resetPose();
   }
   this.camera.parent.rotation.y = (Math.PI / 2.0) + angleRad - theta;


### PR DESCRIPTION
atm the current camera rotation is not accounted for when setting up a new hotspot-started scene.  This can have the effect of images seeming to have the wrong orientation when loading after a hotspot is selected.  

the display.theta_ is for desktops and the display.poseSensor_.resetPose() is for mobile devices. (including when touch panning is used and whether or not they have a working accelerometer)

This fixes issue https://github.com/googlevr/vrview/issues/167 