### PR TITLE
Change order of rotation to yaw and then pitch

### DIFF
--- a/src/embed/hotspot-renderer.js
+++ b/src/embed/hotspot-renderer.js
@@ -105,7 +105,7 @@ HotspotRenderer.prototype.add = function(pitch, yaw, radius, distance, id) {
 
   // Position the hotspot based on the pitch and yaw specified.
   var quat = new THREE.Quaternion();
-  quat.setFromEuler(new THREE.Euler(THREE.Math.degToRad(pitch), THREE.Math.degToRad(yaw), 0));
+  quat.setFromEuler(new THREE.Euler(THREE.Math.degToRad(pitch), THREE.Math.degToRad(yaw), 0, 'YXZ'));
   hotspot.position.applyQuaternion(quat);
   hotspot.lookAt(new THREE.Vector3());
 


### PR DESCRIPTION
THREE is using local axis to rotate using Euler and the order is 'XYZ'
by default. Before this change, it would rotate around X first for
"pitch" which would make local Y is than world Y, once it rotates around
local "Y" for yaw the hotspot would end up being in the wrong place.
This is not visible in the hotspots example as no pitch is set on any of
the hotspots.