### PR TITLE
Add 'allow="vr"' Feature Policy attribute to iframe to permit WebVR

### DIFF
--- a/src/api/player.js
+++ b/src/api/player.js
@@ -163,6 +163,7 @@ Player.prototype.createIframe_ = function(contentInfo) {
   var iframe = document.createElement('iframe');
   iframe.setAttribute('allowfullscreen', true);
   iframe.setAttribute('scrolling', 'no');
+  iframe.setAttribute('allow', 'vr');
   iframe.style.border = 0;
 
   // Handle iframe size if width and height are specified.


### PR DESCRIPTION
Add 'allow="vr"' Feature Policy attribute to permit WebVR in cross-origin iframes. As discussed in https://github.com/googlevr/vrview/issues/274#issuecomment-345392899 .

https://github.com/w3c/webvr/issues/86
https://developers.google.com/web/updates/2017/09/webvr-origin-trial-chrome-62
https://bugs.chromium.org/p/chromium/issues/detail?id=666767