### PR TITLE
fix hotspot gaze click using bind

### DIFF
--- a/src/embed/hotspot-renderer.js
+++ b/src/embed/hotspot-renderer.js
@@ -353,11 +353,11 @@ HotspotRenderer.prototype.focus_ = function(id) {
   this.tween = new TWEEN.Tween(hotspot.scale).to(FOCUS_SCALE, FOCUS_DURATION)
       .easing(TWEEN.Easing.Quadratic.InOut)
       .start();
-  
+
   if (this.worldRenderer.isVRMode()) {
     this.timeForHospotClick = setTimeout(function () {
       this.emit('click', id);
-    }, 1200 )
+    }.bind( this ), 1200 )
   }
 };
 
@@ -367,7 +367,7 @@ HotspotRenderer.prototype.blur_ = function(id) {
   this.tween = new TWEEN.Tween(hotspot.scale).to(NORMAL_SCALE, FOCUS_DURATION)
       .easing(TWEEN.Easing.Quadratic.InOut)
       .start();
-  
+
   if (this.timeForHospotClick) {
     clearTimeout( this.timeForHospotClick );
   }


### PR DESCRIPTION
https://github.com/googlevr/vrview/commit/8966d4f451245163092a248700ba2805bedaef42 broke gaze-to-click 

```.bind( this )``` is used here (instead of an arrow function)

this pr is an es5 friendly version of https://github.com/googlevr/vrview/pull/291

